### PR TITLE
feat: manage projects and site copy in emdash

### DIFF
--- a/.emdash/seed.json
+++ b/.emdash/seed.json
@@ -1,0 +1,465 @@
+{
+  "$schema": "https://emdashcms.com/seed.schema.json",
+  "version": "1",
+  "defaultLocale": "en",
+  "meta": {
+    "name": "A de Alma",
+    "description": "Site content for adealma.com"
+  },
+  "collections": [
+    {
+      "slug": "projects",
+      "label": "Projects",
+      "labelSingular": "Project",
+      "description": "The rehabilitation projects listed on the site.",
+      "icon": "image",
+      "supports": ["drafts", "revisions"],
+      "urlPattern": "/projects/{slug}",
+      "fields": [
+        {
+          "slug": "title",
+          "label": "Title",
+          "type": "string",
+          "required": true,
+          "searchable": true,
+          "translatable": false
+        },
+        {
+          "slug": "location",
+          "label": "Location",
+          "type": "string",
+          "required": true,
+          "translatable": false
+        },
+        {
+          "slug": "sale_status",
+          "label": "Status",
+          "type": "select",
+          "required": true,
+          "translatable": false,
+          "validation": {
+            "options": ["ongoing", "sold", "on_sale"]
+          }
+        },
+        {
+          "slug": "date",
+          "label": "Start year",
+          "type": "string",
+          "required": true,
+          "translatable": false
+        },
+        {
+          "slug": "end_date",
+          "label": "End year",
+          "type": "string",
+          "translatable": false
+        },
+        {
+          "slug": "images",
+          "label": "Images",
+          "type": "repeater",
+          "required": true,
+          "translatable": false,
+          "validation": {
+            "subFields": [
+              {
+                "slug": "filename",
+                "type": "string",
+                "label": "File",
+                "required": true
+              },
+              {
+                "slug": "alt",
+                "type": "string",
+                "label": "Alt text",
+                "required": true
+              }
+            ],
+            "minItems": 1
+          }
+        },
+        {
+          "slug": "description",
+          "label": "Description",
+          "type": "text",
+          "required": true,
+          "searchable": true,
+          "options": {
+            "rows": 8
+          }
+        }
+      ]
+    },
+    {
+      "slug": "site_copy",
+      "label": "Site copy",
+      "labelSingular": "Site copy",
+      "description": "The text on the home, about and projects pages.",
+      "icon": "text",
+      "supports": ["drafts", "revisions"],
+      "fields": [
+        {
+          "slug": "site_name",
+          "label": "Site name",
+          "type": "string",
+          "required": true
+        },
+        {
+          "slug": "site_slogan",
+          "label": "Slogan",
+          "type": "string",
+          "required": true
+        },
+        {
+          "slug": "description",
+          "label": "Home description",
+          "type": "text",
+          "required": true,
+          "options": {
+            "rows": 5
+          }
+        },
+        {
+          "slug": "about_title",
+          "label": "About title",
+          "type": "string",
+          "required": true
+        },
+        {
+          "slug": "about_description",
+          "label": "About paragraphs",
+          "type": "repeater",
+          "required": true,
+          "validation": {
+            "subFields": [
+              {
+                "slug": "text",
+                "type": "text",
+                "label": "Paragraph",
+                "required": true
+              }
+            ],
+            "minItems": 1
+          }
+        },
+        {
+          "slug": "about_images",
+          "label": "About images",
+          "type": "repeater",
+          "required": true,
+          "translatable": false,
+          "validation": {
+            "subFields": [
+              {
+                "slug": "filename",
+                "type": "string",
+                "label": "File",
+                "required": true
+              },
+              {
+                "slug": "alt",
+                "type": "string",
+                "label": "Alt text",
+                "required": true
+              }
+            ],
+            "minItems": 1
+          }
+        },
+        {
+          "slug": "projects_title",
+          "label": "Projects title",
+          "type": "string",
+          "required": true
+        },
+        {
+          "slug": "projects_description",
+          "label": "Projects paragraphs",
+          "type": "repeater",
+          "required": true,
+          "validation": {
+            "subFields": [
+              {
+                "slug": "text",
+                "type": "text",
+                "label": "Paragraph",
+                "required": true
+              }
+            ],
+            "minItems": 1
+          }
+        }
+      ]
+    }
+  ],
+  "content": {
+    "projects": [
+      {
+        "id": "project:casa-do-cristelo:en",
+        "slug": "casa-do-cristelo",
+        "status": "published",
+        "locale": "en",
+        "data": {
+          "title": "casa do cristelo",
+          "location": "caminha, portugal",
+          "date": "2022",
+          "images": [
+            {
+              "filename": "casa-do-cristelo/1",
+              "alt": "construction site"
+            },
+            {
+              "filename": "casa-do-cristelo/2",
+              "alt": "stairs"
+            },
+            {
+              "filename": "casa-do-cristelo/3",
+              "alt": "construction structure"
+            }
+          ],
+          "end_date": "2024",
+          "sale_status": "sold",
+          "description": "Five minutes from Moledo beach and with a sea views, this three bedroom villa enjoys the rural tranquility of Cristelo and easy access to urban centers. Swimming pool, large garden and a central terrace, connecting the two modules of the house, invite to enjoy the outdoor life. The villa preserves the main façade and stone and wood elements of the original construction, which gives it a remarkable character."
+        }
+      },
+      {
+        "id": "project:casa-do-cristelo:pt",
+        "slug": "casa-do-cristelo",
+        "status": "published",
+        "locale": "pt",
+        "data": {
+          "title": "casa do cristelo",
+          "location": "caminha, portugal",
+          "date": "2022",
+          "images": [
+            {
+              "filename": "casa-do-cristelo/1",
+              "alt": "construction site"
+            },
+            {
+              "filename": "casa-do-cristelo/2",
+              "alt": "stairs"
+            },
+            {
+              "filename": "casa-do-cristelo/3",
+              "alt": "construction structure"
+            }
+          ],
+          "end_date": "2024",
+          "sale_status": "sold",
+          "description": "Situada a cinco minutos da praia de Moledo e com vista de mar, esta moradia V3 goza da tranquilidade rural de Cristelo e do acesso fácil aos centros urbanos. Piscina, amplo jardim e um terreiro central, ligando os dois módulos da casa, convidam à fruição da vida ao ar livre. A moradia preserva a fachada principal e elementos em pedra e madeira da construção original, o que lhe atribui um carácter notável."
+        },
+        "translationOf": "project:casa-do-cristelo:en"
+      },
+      {
+        "id": "project:casas-da-matriz:en",
+        "slug": "casas-da-matriz",
+        "status": "published",
+        "locale": "en",
+        "data": {
+          "title": "casas da matriz",
+          "location": "caminha, portugal",
+          "date": "2022",
+          "images": [
+            {
+              "filename": "casas-da-matriz/1",
+              "alt": "street view"
+            },
+            {
+              "filename": "casas-da-matriz/2",
+              "alt": "one of the houses"
+            },
+            {
+              "filename": "casas-da-matriz/3",
+              "alt": "detail of the facade"
+            }
+          ],
+          "end_date": "",
+          "sale_status": "ongoing",
+          "description": "In the historic centre of Caminha, next to the parish church, the union of two buildings gave rise to five flats: two studio flats and three two-bedroom flats. Of the exemplary intervention, one must highlight the perfect distinction of the original façades, composing a classic frontage with the colours of Alto Minho, green and blue. It is also worth mentioning the construction of a lobby, which allowed the creation of an interior garden between flats. Stone and wood are the privileged materials."
+        }
+      },
+      {
+        "id": "project:casas-da-matriz:pt",
+        "slug": "casas-da-matriz",
+        "status": "published",
+        "locale": "pt",
+        "data": {
+          "title": "casas da matriz",
+          "location": "caminha, portugal",
+          "date": "2022",
+          "images": [
+            {
+              "filename": "casas-da-matriz/1",
+              "alt": "street view"
+            },
+            {
+              "filename": "casas-da-matriz/2",
+              "alt": "one of the houses"
+            },
+            {
+              "filename": "casas-da-matriz/3",
+              "alt": "detail of the facade"
+            }
+          ],
+          "end_date": "",
+          "sale_status": "ongoing",
+          "description": "No centro histórico de Caminha, junto à Igreja Matriz, a união de dois edifícios deu origem a cinco apartamentos: dois T0 e três T2. Da intervenção exemplar, realce-se a perfeita distinção das fachadas originais, compondo uma frontaria clássica com as cores do Alto Minho, verde e azul. Destaque-se também a construção de um saguão, que permitiu criar um jardim interior entre apartamentos. Pedra e madeira são os materiais privilegiados."
+        },
+        "translationOf": "project:casas-da-matriz:en"
+      },
+      {
+        "id": "project:casa-do-pescador:en",
+        "slug": "casa-do-pescador",
+        "status": "published",
+        "locale": "en",
+        "data": {
+          "title": "casa do pescador",
+          "location": "caminha, portugal",
+          "date": "2021",
+          "images": [
+            {
+              "filename": "casa-do-pescador/1",
+              "alt": "street view"
+            },
+            {
+              "filename": "casa-do-pescador/2",
+              "alt": "detail of vase"
+            },
+            {
+              "filename": "casa-do-pescador/3",
+              "alt": "detail of the door"
+            }
+          ],
+          "end_date": "2022",
+          "sale_status": "sold",
+          "description": "In an old fishing neighbourhood in Caminha, near the beach, modern architectural solutions have enhanced this modest-sized typical house, now a two-bedroom with kitchenette and optimised space. The open ceiling, with exposed wooden trusses, creates amplitude and luminosity. The façade and the mosaic on the patio floor are traditional elements that harmoniously combine with the minimalist design."
+        }
+      },
+      {
+        "id": "project:casa-do-pescador:pt",
+        "slug": "casa-do-pescador",
+        "status": "published",
+        "locale": "pt",
+        "data": {
+          "title": "casa do pescador",
+          "location": "caminha, portugal",
+          "date": "2021",
+          "images": [
+            {
+              "filename": "casa-do-pescador/1",
+              "alt": "street view"
+            },
+            {
+              "filename": "casa-do-pescador/2",
+              "alt": "detail of vase"
+            },
+            {
+              "filename": "casa-do-pescador/3",
+              "alt": "detail of the door"
+            }
+          ],
+          "end_date": "2022",
+          "sale_status": "sold",
+          "description": "Num velho bairro piscatório de Caminha, perto da praia, as soluções da arquitetura moderna valorizaram esta casa típica de dimensão modesta, hoje um T2 com kitchenette e espaço otimizado. O teto aberto, com asnas de madeira à vista, cria amplitude e luminosidade. A fachada e o mosaico no chão do pátio são elementos tradicionais que harmoniosamente se conciliam com o design minimalista."
+        },
+        "translationOf": "project:casa-do-pescador:en"
+      }
+    ],
+    "site_copy": [
+      {
+        "id": "site-copy:en",
+        "slug": "site-copy",
+        "status": "published",
+        "locale": "en",
+        "data": {
+          "site_name": "a de alma",
+          "site_slogan": "rehabilitation with soul",
+          "description": "To rehabilitate is to feel the identity of the place. It is wanting to hand over history to new protagonists. Rare houses then emerge, houses with soul, open to new plans of life.",
+          "about_title": "about",
+          "about_description": [
+            {
+              "text": "A de Alma [alma = soul]. The name reflects our passion for building rehabilitation and the unique essence of each project we undertake."
+            },
+            {
+              "text": "The preservation of heritage and the reinterpretation of space are the coordinates of our interventions. In A de Alma houses, there is a strong sense of belonging to the territory. There are solid roots, sustaining the lightness and fluidity of contemporary environments."
+            }
+          ],
+          "about_images": [
+            {
+              "filename": "about-1",
+              "alt": "boat stopped in the river"
+            },
+            {
+              "filename": "about-2",
+              "alt": "stones to be used in construction"
+            },
+            {
+              "filename": "about-3",
+              "alt": "street with houses to be rehabilitated"
+            }
+          ],
+          "projects_title": "projects",
+          "projects_description": [
+            {
+              "text": "Fully integrated into their surroundings, the houses are the result of demanding rehabilitation programmes. The restoration of iconic elements of the original architecture and the redimensioning of the space to meet current standards of wellbeing can be seen in them."
+            },
+            {
+              "text": "Both in the great architectural solutions and in the fusion between local tradition and new design, it is the noble materials that allow the ideals of enjoyment, functionality and comfort to be fulfilled."
+            },
+            {
+              "text": "Regardless the common criteria, each house has unique qualities, a charm that is all its own."
+            }
+          ]
+        }
+      },
+      {
+        "id": "site-copy:pt",
+        "slug": "site-copy",
+        "status": "published",
+        "locale": "pt",
+        "data": {
+          "site_name": "a de alma",
+          "site_slogan": "reabilitação com alma",
+          "description": "Reabilitar é sentir a identidade do lugar. É querer entregar a história a novos protagonistas. Surgem então casas raras, casas com alma, abertas a novos planos da vida.",
+          "about_title": "sobre",
+          "about_description": [
+            {
+              "text": "A de Alma. O nome traduz a nossa paixão pela reabilitação de edifícios e a essência especial de cada projeto a que nos dedicamos."
+            },
+            {
+              "text": "A preservação do património e a reinterpretação do espaço são as coordenadas das nossas intervenções. Nas casas A de Alma, há o forte sentido de pertença ao território. Existem raízes sólidas, sustentando a leveza e fluidez de ambientes contemporâneos."
+            }
+          ],
+          "about_images": [
+            {
+              "filename": "about-1",
+              "alt": "barco parado no rio"
+            },
+            {
+              "filename": "about-2",
+              "alt": "pedras a ser usadas na construção"
+            },
+            {
+              "filename": "about-3",
+              "alt": "ruas com propriedades a reabilitar"
+            }
+          ],
+          "projects_title": "projetos",
+          "projects_description": [
+            {
+              "text": "Plenamente integradas no meio envolvente, as casas resultam de programas de reabilitação exigentes. Denotam o restauro de elementos icónicos da arquitetura original e o redimensionamento do espaço, feito ao encontro dos padrões atuais de bem-estar."
+            },
+            {
+              "text": "Tanto nas grandes soluções arquitetónicas como na fusão entre tradição local e novo design, são os materiais nobres que deixam cumprir os ideais de fruição, funcionalidade e conforto."
+            },
+            {
+              "text": "À parte os critérios comuns, cada casa tem qualidades únicas, um charme que é só seu."
+            }
+          ]
+        },
+        "translationOf": "site-copy:en"
+      }
+    ]
+  }
+}

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -25,6 +25,11 @@ export default defineConfig({
   // One canonical form per page: without this both /about and /about/ resolve
   // and the sitemap advertises both.
   trailingSlash: "never",
+  // Shortcut to the EmDash admin, which lives under the reserved /_emdash
+  // prefix that the integration injects.
+  redirects: {
+    "/admin": "/_emdash/admin",
+  },
   vite: {
     plugins: [tailwindcss()],
   },

--- a/src/components/Logo.astro
+++ b/src/components/Logo.astro
@@ -7,7 +7,7 @@ interface Props {
 }
 
 const { locale } = Astro.props;
-const copy = getCopy(locale);
+const copy = await getCopy(Astro.locals, locale);
 ---
 
 <span class="inline-flex items-center font-bold tracking-[.15em] text-primary-900">

--- a/src/components/pages/About.astro
+++ b/src/components/pages/About.astro
@@ -11,7 +11,7 @@ interface Props {
 }
 
 const { locale } = Astro.props;
-const copy = getCopy(locale);
+const copy = await getCopy(Astro.locals, locale);
 const body =
   "mb-12 break-normal px-8 text-xl leading-[28px] md:pr-32 md:text-2xl md:leading-[30px] lg:pl-24 lg:pr-64 xl:pl-48 xl:pr-96 xl:text-3xl xl:leading-[40px] 2xl:pr-[35rem]";
 ---

--- a/src/components/pages/Home.astro
+++ b/src/components/pages/Home.astro
@@ -14,7 +14,7 @@ interface Props {
 }
 
 const { locale } = Astro.props;
-const copy = getCopy(locale);
+const copy = await getCopy(Astro.locals, locale);
 ---
 
 <MainLayout description={copy.description} locale={locale}>

--- a/src/components/pages/Project.astro
+++ b/src/components/pages/Project.astro
@@ -14,10 +14,10 @@ interface Props {
 }
 
 const { locale, project } = Astro.props;
-const copy = getCopy(locale);
-const description = getProjectDescription(locale, project.slug);
+const copy = await getCopy(Astro.locals, locale);
+const description = await getProjectDescription(Astro.locals, locale, project.slug);
 
-const projects = getProjects();
+const projects = await getProjects(Astro.locals, locale);
 const index = projects.findIndex((entry) => entry.slug === project.slug);
 const nextProject = projects[index + 1]?.slug ?? "";
 ---

--- a/src/components/pages/Projects.astro
+++ b/src/components/pages/Projects.astro
@@ -13,10 +13,12 @@ interface Props {
 }
 
 const { locale } = Astro.props;
-const copy = getCopy(locale);
+const copy = await getCopy(Astro.locals, locale);
 
 const year = (date: string) => Number.parseInt(date, 10);
-const projects = getProjects().toSorted((a, b) => year(b.date) - year(a.date));
+const projects = (await getProjects(Astro.locals, locale)).toSorted(
+  (a, b) => year(b.date) - year(a.date),
+);
 
 const byYear = new Map<number, typeof projects>();
 for (const project of projects) {

--- a/src/content.ts
+++ b/src/content.ts
@@ -1,3 +1,5 @@
+import { getEmDashCollection, getEmDashEntry } from "emdash";
+
 import copyEn from "./data/copy/en.json";
 import projectsEn from "./data/copy/projects.en.json";
 import projectsPt from "./data/copy/projects.pt.json";
@@ -24,26 +26,49 @@ export interface SiteCopy {
   site_name: string;
   site_slogan: string;
   description: string;
-  about_title: string;
   about_description: string[];
+  about_title: string;
   about_images: ProjectImage[];
   projects_title: string;
   projects_description: string[];
 }
 
-const copy: Record<Locale, SiteCopy> = {
+/**
+ * A project as EmDash stores it. Field slugs have to be snake_case, and `slug`
+ * and `status` are reserved for the entry itself, so the sale state is held in
+ * `sale_status`; `data.slug` is the entry's own slug. Both are renamed back
+ * when read.
+ */
+interface ProjectRow extends Omit<Project, "endDate" | "status"> {
+  end_date: string;
+  sale_status: string;
+  description: string;
+}
+
+/** A project plus its localised text, in the shape the pages expect. */
+interface ProjectEntry extends Project {
+  description: string;
+}
+
+/** EmDash stores the paragraph lists as repeater rows. */
+interface Paragraph {
+  text: string;
+}
+
+interface SiteCopyEntry extends Omit<SiteCopy, "about_description" | "projects_description"> {
+  about_description: Paragraph[];
+  projects_description: Paragraph[];
+}
+
+const bundledCopy: Record<Locale, SiteCopy> = {
   en: copyEn,
   pt: copyPt,
 };
 
-const descriptions: Record<Locale, Record<string, { description: string }>> = {
+const bundledDescriptions: Record<Locale, Record<string, { description: string }>> = {
   en: projectsEn,
   pt: projectsPt,
 };
-
-export function getCopy(locale: Locale): SiteCopy {
-  return copy[locale];
-}
 
 const STATUSES = new Set(["ongoing", "sold", "on_sale"]);
 
@@ -51,7 +76,12 @@ function isProjectStatus(value: string): value is Project["status"] {
   return STATUSES.has(value);
 }
 
-export function getProjects(): Project[] {
+/** Narrows a stored row so its sale state can be used as the project status. */
+function hasKnownStatus(row: ProjectRow): row is ProjectRow & { sale_status: Project["status"] } {
+  return isProjectStatus(row.sale_status);
+}
+
+function bundledProjects(): Project[] {
   return projectsData.map((entry) => {
     if (!isProjectStatus(entry.status)) {
       throw new Error(`Unknown project status "${entry.status}" for ${entry.slug}`);
@@ -60,6 +90,85 @@ export function getProjects(): Project[] {
   });
 }
 
-export function getProjectDescription(locale: Locale, slug: string): string {
-  return descriptions[locale][slug]?.description ?? "";
+/**
+ * Cache each query on `locals` so a layout and the page it renders share one
+ * database read. Module scope is reused across requests in a Worker, so the
+ * cache has to be request-scoped rather than global.
+ */
+type Cache = App.Locals & {
+  copy?: Map<Locale, Promise<SiteCopy>>;
+  projects?: Map<Locale, Promise<ProjectEntry[]>>;
+};
+
+function cached<T>(store: Map<Locale, Promise<T>>, locale: Locale, load: () => Promise<T>) {
+  const hit = store.get(locale);
+  if (hit) return hit;
+  const pending = load();
+  store.set(locale, pending);
+  return pending;
+}
+
+export function getCopy(locals: App.Locals, locale: Locale): Promise<SiteCopy> {
+  const cache = locals as Cache;
+  cache.copy ??= new Map();
+  return cached(cache.copy, locale, () => loadCopy(locale));
+}
+
+async function loadCopy(locale: Locale): Promise<SiteCopy> {
+  try {
+    const { entry } = await getEmDashEntry<"site_copy", SiteCopyEntry>("site_copy", "site-copy", {
+      locale,
+    });
+    if (!entry) return bundledCopy[locale];
+    return {
+      ...entry.data,
+      about_description: entry.data.about_description.map((row) => row.text),
+      projects_description: entry.data.projects_description.map((row) => row.text),
+    };
+  } catch {
+    return bundledCopy[locale];
+  }
+}
+
+function getProjectEntries(locals: App.Locals, locale: Locale): Promise<ProjectEntry[]> {
+  const cache = locals as Cache;
+  cache.projects ??= new Map();
+  return cached(cache.projects, locale, () => loadProjects(locale));
+}
+
+async function loadProjects(locale: Locale): Promise<ProjectEntry[]> {
+  try {
+    const { entries } = await getEmDashCollection<"projects", ProjectRow>("projects", {
+      locale,
+      status: "published",
+    });
+    const projects = entries
+      .map(({ data }) => data)
+      .filter(hasKnownStatus)
+      .map(({ end_date, sale_status, ...data }) => ({
+        ...data,
+        endDate: end_date,
+        status: sale_status,
+      }));
+    if (projects.length > 0) return projects;
+  } catch {
+    // Fall through to the copy that shipped with the build.
+  }
+  return bundledProjects().map((project) => ({
+    ...project,
+    description: bundledDescriptions[locale][project.slug]?.description ?? "",
+  }));
+}
+
+export async function getProjects(locals: App.Locals, locale: Locale): Promise<Project[]> {
+  return getProjectEntries(locals, locale);
+}
+
+export async function getProjectDescription(
+  locals: App.Locals,
+  locale: Locale,
+  slug: string,
+): Promise<string> {
+  const entries = await getProjectEntries(locals, locale);
+  return entries.find((entry) => entry.slug === slug)?.description ?? "";
 }

--- a/src/live.config.ts
+++ b/src/live.config.ts
@@ -1,0 +1,8 @@
+import { defineLiveCollection } from "astro:content";
+import { emdashLoader } from "emdash/runtime";
+
+export const collections = {
+  _emdash: defineLiveCollection({
+    loader: emdashLoader(),
+  }),
+};

--- a/src/pages/[locale]/projects/[slug].astro
+++ b/src/pages/[locale]/projects/[slug].astro
@@ -5,9 +5,14 @@ import { isLocale } from "../../../i18n/ui";
 import { notFound } from "../../../not-found";
 
 const { locale, slug } = Astro.params;
-const project = getProjects().find((entry) => entry.slug === slug);
 
-if (!isLocale(locale) || !project) {
+if (!isLocale(locale)) {
+  return notFound(Astro.rewrite);
+}
+
+const project = (await getProjects(Astro.locals, locale)).find((entry) => entry.slug === slug);
+
+if (!project) {
   return notFound(Astro.rewrite);
 }
 ---

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -3,7 +3,9 @@ import Project from "../../components/pages/Project.astro";
 import { getProjects } from "../../content";
 import { notFound } from "../../not-found";
 
-const project = getProjects().find((entry) => entry.slug === Astro.params.slug);
+const project = (await getProjects(Astro.locals, "en")).find(
+  (entry) => entry.slug === Astro.params.slug,
+);
 
 if (!project) {
   return notFound(Astro.rewrite);


### PR DESCRIPTION
## Summary

The EmDash admin was showing nothing but the default empty `pages` and `posts` collections, because the site's content never made it into the CMS. This moves it there.

- Add `.emdash/seed.json` with two collections, generated from the JSON the site already shipped so the copy transfers verbatim:
  - **projects** — one entry per project per locale (6 total). `title`, `location`, `date`, `end_date`, `images` and the sale status are marked non-translatable, so they stay in sync across locales; only `description` differs per locale.
  - **site_copy** — the home, about and projects page text, one entry per locale.
- Add `src/live.config.ts`. Without the `_emdash` live collection, every `getEmDashCollection`/`getEmDashEntry` call fails with `Collection "_emdash" is not a live collection`, so the CMS could never have been read even once seeded. casadacevada already had this file; adealma never did.
- Rewrite `src/content.ts` to read from EmDash, caching each query on `locals` so a layout and its page share one database read, and falling back to the bundled JSON whenever the CMS cannot answer.

Two field slugs had to be renamed: `slug` and `status` are reserved by EmDash for the entry itself, and slugs must be snake_case. The sale state is stored as `sale_status` and `endDate` as `end_date`; both are renamed back at the boundary, so the templates are untouched.

## Verification

- `check-types`, `lint --deny-warnings`, `format:check`, and a production build: all clean.
- Seeded a local D1 and confirmed the pages render from it: changing `location` in the database changed `/projects`, and changing the English `site_slogan` changed `/` while leaving `/pt` alone.
- All routes still serve: `/`, `/pt`, `/about`, `/pt/about`, `/projects`, `/pt/projects`, and both locales of `/projects/casa-do-cristelo`, with the correct per-locale descriptions.
- With the CMS empty, every page falls back to the bundled JSON and renders exactly as before.

Note: `location`, `status`, `year`, `sold`, `ongoing` and `on_sale` in `src/data/copy/*.json` are dead keys. The interface labels come from `src/i18n/ui.ts`, so they are not modelled in the CMS.